### PR TITLE
feat: 운동 기록 목록 조회 API 구현

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,6 +9,7 @@ const errorHandler = require('./middlewares/error-handler');
 
 // 라우터 import
 const groupRoutes = require('./routes/groups');
+const recordsRoutes = require('./routes/records');
 
 const app = express();
 const { STATUS_CODE } = require('./utils/const');
@@ -20,10 +21,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // 라우터 연결
-
-const groupRoutes = require('./routes/groups');
-
 app.use('/groups', groupRoutes);
+app.use('/groups', recordsRoutes);
 
 // 기본 라우트
 app.get('/', (req, res) => {
@@ -63,4 +62,5 @@ app.use((err, req, res, next) => {
 const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
-  console.log(`서버가 ${PORT}번 포트에서 실행 중입니다.`);
+  console.log(`서버가 ${PORT}번 포트에서 실행 중입니다.`)
+});

--- a/backend/controllers/records-controller.js
+++ b/backend/controllers/records-controller.js
@@ -1,0 +1,85 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+class RecordController {
+  /**
+   *  운동 기록 목록 조회
+   */
+  static async getGroupRecords(req, res, next) {
+    try {
+      const { groupId } = req.params;
+      const {
+        page = 1,
+        limit = 10,
+        order = 'desc',
+        orderBy = 'createdAt',
+        search = '',
+        sport = '', 
+      } = req.query;
+
+      const groupIdNum = Number(groupId);
+      if (isNaN(groupIdNum)) {
+        return res.status(400).json({ message: 'Invalid groupId' });
+      }
+
+      const group = await prisma.group.findUnique({ where: { id: groupIdNum } });
+      if (!group) return res.status(404).json({ message: 'Group not found' });
+
+      // 그룹에 속한 userId 리스트 조회
+      const participants = await prisma.participant.findMany({
+        where: { groupId: groupIdNum },
+        select: { userId: true },
+      });
+      const userIds = participants.map(p => p.userId);
+
+      // 정렬 조건
+      const sortField = orderBy === 'time' ? 'duration' : 'createdAt';
+      const sortOrder = ['asc', 'desc'].includes(order) ? order : 'desc';
+
+      const where = {
+        userId: { in: userIds },
+        ...(sport && { sport }), 
+        user: {
+          nickname: { contains: search.trim(), mode: 'insensitive' },
+        },
+      };
+
+      const pageNum = parseInt(page, 10) || 1;
+      const limitNum = parseInt(limit, 10) || 10;
+      const offset = (pageNum - 1) * limitNum;
+
+      const [total, records] = await Promise.all([
+        prisma.exerciseRecord.count({ where }),
+        prisma.exerciseRecord.findMany({
+          where,
+          orderBy: { [sortField]: sortOrder },
+          skip: offset,
+          take: limitNum,
+          include: {
+            user: { select: { id: true, nickname: true } },
+            photo: { select: { url: true } },
+          },
+        }),
+      ]);
+      // 응답 데이터 가공
+      const data = records.map(record => ({
+        id: record.id,
+        exerciseType: record.sport,
+        description: record.description,
+        time: record.duration,
+        distance: record.distance,
+        photos: record.photo.map(p => p.url),
+        author: {
+          id: record.user.id,
+          nickname: record.user.nickname,
+        },
+      }));
+
+      return res.status(200).json({ data, total });
+    } catch (err) {
+      next(err);
+    }
+  }
+}
+
+module.exports = RecordController;

--- a/backend/routes/records.js
+++ b/backend/routes/records.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const RecordsController = require('../controllers/records-controller');
+
+const router = express.Router();
+
+/**
+ * 운동 기록 목록 조회 API
+ * GET /:groupId/records
+ */
+router.get('/:groupId/records', RecordsController.getGroupRecords);
+
+module.exports = router;


### PR DESCRIPTION
## feat: 운동 기록 목록 조회 API 구현

## 📝 요구사항
- [x] 기록 목록 조회
- 그룹 내에 등록된 모든 유저의 운동 기록 조회가 가능합니다.
- 닉네임, 운동 종류, 시간, 거리, 사진이 표시됩니다.
- 최신순, 운동시간순으로 정렬 가능합니다.
- 닉네임으로 검색 가능합니다.
- 페이지네이션이 가능합니다.

## ✨ 주요 변경사항
static으로 변경 완료
스키마 변경 후 테스트 완료

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1a001fb6-c28a-427f-bf36-5d23249b9f6f)
![image](https://github.com/user-attachments/assets/3c611071-35a7-4a86-877a-58d7448c27e9)
![image](https://github.com/user-attachments/assets/ca063a2f-4228-4aaf-9e85-5a9756fa0b1b)


## 💬 리뷰어에게
main 브랜치 로컬 브랜치에 최신화 작업 완료 했으며,
app.js 파일에 const groupRoutes = require('./routes/groups'); 라우터 코드가 중복되어 있어 하나로 수정했고, 
app.js 마지막 부분 코드에 괄호가 없어 오류가 나서 그 부분도 수정 후 테스트 완료 했습니다!
조심스러워서 고민도 많이하고 하다가 작업 속도가 느려졌습니다 ㅠ
수정할 부분은 코멘트 부탁드려요 🙏🏻