### PR TITLE
fix: app.js 중복 제거, group-controller 내용 수정

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,7 +5,6 @@ require('dotenv').config();
 
 // 라우터 import
 const groupRoutes = require('./routes/groups');
-const recordsRoutes = require('./routes/records');
 const { swaggerSpec, swaggerUi } = require('./swagger/swagger');
 const { STATUS_CODE } = require('./utils/const');
 
@@ -20,8 +19,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // 라우터 연결
-app.use('/groups', groupRoutes);
-app.use('/groups', recordsRoutes);
+app.use('/groups', groupRoutes);  // recordsRoutes 제거
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 기본 라우트

--- a/backend/controllers/group-controller.js
+++ b/backend/controllers/group-controller.js
@@ -13,7 +13,8 @@ class GroupController {
       const {
         page = 1,
         limit = 10,
-        sort = 'latest',
+        orderBy = 'createdAt',
+        order = 'desc',
         search,
       } = req.query;
 
@@ -45,8 +46,8 @@ class GroupController {
 
       let groups;
 
-      // recommend 또는 participants로 정렬하는 경우
-      if (sort === 'recommend' || sort === 'participants') {
+      // orderBy와 order 기반 정렬
+      if (orderBy === 'likeCount' || orderBy === 'participantCount') {
         // 모든 그룹을 조회 (검색 조건 적용)
         const allGroups = await prisma.group.findMany({
           where: whereCondition,
@@ -54,7 +55,6 @@ class GroupController {
             id: true,
             name: true,
             photoUrl: true,
-            badge: true,
             goalRep: true,
             createdAt: true,
             updatedAt: true,
@@ -75,40 +75,31 @@ class GroupController {
                 groupRecommend: true,
               },
             },
-             participants: {
-              select: {
-                id: true,
-                user: {
-                  select: {
-                    nickname: true,
-                  },
-                },
-                createdAt: true,
-                updatedAt: true,
-                
-              },
-            },
           },
         });
 
         // 메모리에서 정렬
         allGroups.sort((a, b) => {
-          if (sort === 'recommend') {
-            return b._count.groupRecommend - a._count.groupRecommend;
-          } else {
-            return b._count.participants - a._count.participants;
+          let compareValue = 0;
+          if (orderBy === 'likeCount') {
+            compareValue = b._count.groupRecommend - a._count.groupRecommend;
+          } else if (orderBy === 'participantCount') {
+            compareValue = b._count.participants - a._count.participants;
           }
+          
+          // order가 'asc'면 순서 반대로
+          return order === 'asc' ? -compareValue : compareValue;
         });
 
         // 페이지네이션 적용
         groups = allGroups.slice(offset, offset + limitNum);
       } else {
-        // latest 정렬 (기본)
+        // createdAt 정렬 (기본)
         groups = await prisma.group.findMany({
           where: whereCondition,
           orderBy: [
             {
-              createdAt: 'desc',
+              createdAt: order === 'asc' ? 'asc' : 'desc',
             },
           ],
           skip: offset,
@@ -117,7 +108,6 @@ class GroupController {
             id: true,
             name: true,
             photoUrl: true,
-            badge: true,
             goalRep: true,
             createdAt: true,
             updatedAt: true,
@@ -138,55 +128,34 @@ class GroupController {
                 groupRecommend: true,
               },
             },
-            participants: {
-              select: {
-                id: true,
-                user: {
-                  select:{
-                    nickname: true,
-                  },
-                },
-                createdAt: true,
-                updatedAt: true,
-                
-              },
-            },
           },
         });
       }
 
-      // 응답 데이터 가공
+      // 응답 데이터 가공 - 프론트엔드 호환성을 위해 추가 필드 포함
       const groupList = groups.map((group) => ({
         id: group.id,
         name: group.name,
-        description: group.description,
+        nickname: group.owner.nickname,
         photoUrl: group.photoUrl,
-        goalRep: group.goalRep,
-        discordWebhookUrl: group.discordWebhookUrl ?? '',
-        discordInviteUrl: group.discordInviteUrl ?? '',
-        likeCount: group._count.groupRecommend,
         tags: group.tag.map((t) => t.name),
+        goalRep: group.goalRep,
+        recommendCount: group._count.groupRecommend,
+        participantCount: group._count.participants,
+        // 프론트엔드 호환을 위한 추가 필드
+        likeCount: group._count.groupRecommend,
+        recordCount: 0, // Record 모델이 아직 없으므로 0으로 설정
         owner: {
           id: group.owner.id,
           nickname: group.owner.nickname,
-          createdAt: new Date(group.owner.createdAt).getTime(),
-          updatedAt: new Date(group.owner.updatedAt).getTime(),
+          createdAt: group.createdAt.getTime(),
+          updatedAt: group.updatedAt.getTime(),
         },
-        participants: group.participants.map(p => ({
-          id: p.id,
-          nickname: p.user.nickname,
-          createdAt: p.createdAt,
-          updatedAt: p.updatedAt,
-        })),
-        createdAt: group.createdAt,
-        updatedAt: group.updatedAt,
-        badges: group.badge,
+        participants: [], // 목록 조회에서는 참여자 상세 정보 불필요
+        badges: [], // 뱃지 기능은 아직 구현되지 않음
+        createdAt: group.createdAt.getTime(),
+        updatedAt: group.updatedAt.getTime(),
       }));
-
-      // 페이지네이션 정보
-      const totalPages = Math.ceil(totalCount / limitNum);
-      const hasNextPage = pageNum < totalPages;
-      const hasPrevPage = pageNum > 1;
 
       res.status(200).json({
         data: groupList,
@@ -222,7 +191,6 @@ class GroupController {
           name: true,
           description: true,
           photoUrl: true,
-          badge: true,
           goalRep: true,
           discordInviteUrl: true,
           createdAt: true,
@@ -253,28 +221,34 @@ class GroupController {
         throw error;
       }
 
-      // 응답 데이터 가공
+      // 응답 데이터 가공 - 프론트엔드 타입에 맞게
       const groupDetail = {
         id: group.id,
         name: group.name,
         description: group.description,
         nickname: group.owner.nickname,
         photoUrl: group.photoUrl,
-        badge: group.badge,
         tags: group.tag.map((t) => t.name),
         goalRep: group.goalRep,
         participantCount: group._count.participants,
-        recommendCount: group._count.groupRecommend,
         discordInviteUrl: group.discordInviteUrl,
-        owner: group.owner,
-        createdAt: group.createdAt,
-        updatedAt: group.updatedAt,
+        // 프론트엔드 타입 호환을 위한 추가 필드
+        discordWebhookUrl: '',
+        likeCount: group._count.groupRecommend,
+        recordCount: 0, // Record 모델이 아직 없으므로 0으로 설정
+        owner: {
+          id: group.owner.id,
+          nickname: group.owner.nickname,
+          createdAt: group.createdAt.getTime(),
+          updatedAt: group.updatedAt.getTime(),
+        },
+        participants: [],
+        badges: [],
+        createdAt: group.createdAt.getTime(),
+        updatedAt: group.updatedAt.getTime(),
       };
 
-      res.status(200).json({
-        success: true,
-        data: groupDetail,
-      });
+      res.status(200).json(groupDetail);
     } catch (error) {
       next(error);
     }
@@ -302,7 +276,7 @@ class GroupController {
           },
         });
         //태그 생성
-        const createedtags = await Promise.all(
+        const createdTags = await Promise.all(
           tags.map(name => 
             tx.tag.create({
               data: { 
@@ -313,7 +287,7 @@ class GroupController {
           )
         );
         //오너 참여자 등록
-        await tx.participant.create({
+        const ownerParticipant = await tx.participant.create({
           data: {
             groupId: group.id,
             userId: owner.id
@@ -333,7 +307,7 @@ class GroupController {
           discordWebhookUrl: group.discordWebhookUrl,
           discordInviteUrl: group.discordInviteUrl,
           likeCount: likeCount,
-          tags: createedtags.map(tag => tag.name),
+          tags: createdTags.map(tag => tag.name),
           owner: {
             id: owner.id,
             nickname: owner.nickname,
@@ -350,14 +324,12 @@ class GroupController {
           ],
           createdAt: group.createdAt.getTime(),
           updatedAt: group.updatedAt.getTime(),
-          badges: group.badge // 초기 상태에서는 빈 배열
+          badges: group.badge || [],
+          recordCount: 0
         };
         return response;
       });
-      res.status(200).json({
-        success: true,
-        data: postGroup,
-      });
+      res.status(200).json(postGroup);
     } catch (error) {
       next(error);
     }
@@ -381,8 +353,17 @@ class GroupController {
               password: true,
             }
           },
-          participants: true,
+          participants: {
+            include: {
+              user: true
+            }
+          },
           tag: true,
+          _count: {
+            select: {
+              groupRecommend: true,
+            }
+          }
         }
       });
       if (!existingGroup) {
@@ -406,35 +387,30 @@ class GroupController {
             tag = await Promise.all(
               tags.map(name => {
                 return tx.tag.create({
-                  data: { name: name,
-                    group: { connect: { id: id }},
+                  data: { 
+                    name: name,
+                    groupId: id
                   },
                 })
               }),
             )
           } else {
             //태그 패치 없을시 기존 태그 가져오기
-            tag = existingGroup. tag;
+            tag = existingGroup.tag;
           }
-          // 오너 업데이트
-          const owner = await tx.user.update({
-            where : { id: existingGroup.owner.id },
-            data: { nickname: ownerNickname }
-          })
+          // 오너 업데이트 (ownerNickname이 있을 때만)
+          let owner = existingGroup.owner;
+          if (ownerNickname) {
+            owner = await tx.user.update({
+              where : { id: existingGroup.owner.id },
+              data: { nickname: ownerNickname }
+            });
+          }
           // 그룹 업데이트
           const group = await tx.group.update({
             where: { id: id },
-            include: {
-              owner: true,
-            },
             data: updateData,
           });
-          // 참여자 조회
-          const participant = await tx.participant.findMany({
-            where: {
-              id: { in: existingGroup.participants.map(participant => participant.id)}
-            }
-          })
           // groupRecommend 카운트
           const likeCount = await tx.groupRecommend.count({
             where: { groupId: group.id },
@@ -453,20 +429,23 @@ class GroupController {
             owner: {
               id: owner.id,
               nickname: owner.nickname,
-              createdAt: owner.createdAt,
-              updatedAt: owner.updatedAt,
+              createdAt: owner.createdAt.getTime(),
+              updatedAt: owner.updatedAt.getTime(),
             },
-            participants: participant,
-            createdAt: group.createdAt,
-            updatedAt: group.updatedAt,
-            badges: group.badge
+            participants: existingGroup.participants.map(p => ({
+              id: p.user.id,
+              nickname: p.user.nickname,
+              createdAt: p.createdAt.getTime(),
+              updatedAt: p.updatedAt.getTime(),
+            })),
+            createdAt: group.createdAt.getTime(),
+            updatedAt: group.updatedAt.getTime(),
+            badges: group.badge || [],
+            recordCount: 0 // Record 모델이 아직 없으므로 0으로 설정
           };
           return response
         });
-        return res.status(200).json({
-          success: true,
-          data: patchGroup,
-        });
+        return res.status(200).json(patchGroup);
       } else {
         return res.status(403).json({ error: '비밀번호가 틀렸습니다.' });
       }
@@ -513,14 +492,9 @@ class GroupController {
   static async recommendGroup(req, res, next) {
     try {
       const { groupId } = req.params;
-      const { userId } = req.body;
-
-      // 필수 값 검증
-      if (!userId) {
-        const error = new Error('사용자 ID가 필요합니다.');
-        error.status = 400;
-        throw error;
-      }
+      // 프론트엔드에서 userId를 보내지 않으므로 임시 처리
+      // 실제로는 인증 미들웨어에서 req.user.id 등으로 가져와야 함
+      const userId = req.body.userId || 1; // 임시로 1로 설정
 
       const groupIdInt = parseInt(groupId, 10);
       const userIdInt = parseInt(userId, 10);
@@ -559,18 +533,8 @@ class GroupController {
         },
       });
 
-      // 생성 후 현재 추천 수 조회
-      const recommendCount = await prisma.groupRecommend.count({
-        where: { groupId: groupIdInt },
-      });
-
       res.status(200).json({
-        success: true,
         message: '그룹을 추천했습니다.',
-        data: {
-          groupId: groupIdInt,
-          recommendCount,
-        },
       });
     } catch (error) {
       next(error);
@@ -584,14 +548,8 @@ class GroupController {
   static async unrecommendGroup(req, res, next) {
     try {
       const { groupId } = req.params;
-      const { userId } = req.body;
-
-      // 필수 값 검증
-      if (!userId) {
-        const error = new Error('사용자 ID가 필요합니다.');
-        error.status = 400;
-        throw error;
-      }
+      // 프론트엔드에서 userId를 보내지 않으므로 임시 처리
+      const userId = req.body.userId || 1; // 임시로 1로 설정
 
       const groupIdInt = parseInt(groupId, 10);
       const userIdInt = parseInt(userId, 10);
@@ -627,12 +585,9 @@ class GroupController {
         where: { id: existingRecommend.id },
       });
 
-      // 삭제 후 현재 추천 수 조회
-      const recommendCount = await prisma.groupRecommend.count({
-        where: { groupId: groupIdInt },
+      res.status(200).json({
+        message: '그룹 추천을 취소했습니다.',
       });
-
-      res.status(204).send();
     } catch (error) {
       next(error);
     }

--- a/backend/controllers/group-controller.js
+++ b/backend/controllers/group-controller.js
@@ -57,6 +57,7 @@ class GroupController {
             badge: true,
             goalRep: true,
             createdAt: true,
+            updatedAt: true,
             owner: {
               select: {
                 id: true,
@@ -72,6 +73,19 @@ class GroupController {
               select: {
                 participants: true,
                 groupRecommend: true,
+              },
+            },
+             participants: {
+              select: {
+                id: true,
+                user: {
+                  select: {
+                    nickname: true,
+                  },
+                },
+                createdAt: true,
+                updatedAt: true,
+                
               },
             },
           },
@@ -106,6 +120,7 @@ class GroupController {
             badge: true,
             goalRep: true,
             createdAt: true,
+            updatedAt: true,
             owner: {
               select: {
                 id: true,
@@ -123,6 +138,19 @@ class GroupController {
                 groupRecommend: true,
               },
             },
+            participants: {
+              select: {
+                id: true,
+                user: {
+                  select:{
+                    nickname: true,
+                  },
+                },
+                createdAt: true,
+                updatedAt: true,
+                
+              },
+            },
           },
         });
       }
@@ -131,14 +159,28 @@ class GroupController {
       const groupList = groups.map((group) => ({
         id: group.id,
         name: group.name,
-        nickname: group.owner.nickname,
+        description: group.description,
         photoUrl: group.photoUrl,
-        badge: group.badge,
-        tags: group.tag.map((t) => t.name),
         goalRep: group.goalRep,
-        recommendCount: group._count.groupRecommend,
-        participantCount: group._count.participants,
+        discordWebhookUrl: group.discordWebhookUrl ?? '',
+        discordInviteUrl: group.discordInviteUrl ?? '',
+        likeCount: group._count.groupRecommend,
+        tags: group.tag.map((t) => t.name),
+        owner: {
+          id: group.owner.id,
+          nickname: group.owner.nickname,
+          createdAt: new Date(group.owner.createdAt).getTime(),
+          updatedAt: new Date(group.owner.updatedAt).getTime(),
+        },
+        participants: group.participants.map(p => ({
+          id: p.id,
+          nickname: p.user.nickname,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+        })),
         createdAt: group.createdAt,
+        updatedAt: group.updatedAt,
+        badges: group.badge,
       }));
 
       // 페이지네이션 정보
@@ -147,18 +189,8 @@ class GroupController {
       const hasPrevPage = pageNum > 1;
 
       res.status(200).json({
-        success: true,
-        data: {
-          groups: groupList,
-          pagination: {
-            currentPage: pageNum,
-            totalPages,
-            totalCount,
-            hasNextPage,
-            hasPrevPage,
-            limit: limitNum,
-          },
-        },
+        data: groupList,
+        total: totalCount,
       });
     } catch (error) {
       next(error);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -21,7 +21,12 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'sprint-be-project.s3.ap-northeast-2.amazonaws.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'example.com', //추가된 내용
+      }
     ],
+  
   },
 };
 


### PR DESCRIPTION


## ✨ 주요 변경사항
group-controller 상세 조회 응답에서 success:true와 data 래핑 제거, 추천 취소에서 204 No Content 대신 200 OK로 변경, 쿼리 파라미터 orderBy와 order 사용, feat: next.config.ts 내용 추가
## 📸 스크린샷 (선택)

![세븐 홈페이지 화면](https://github.com/user-attachments/assets/6bd377da-3761-47d6-994a-b313d5386ed2)

---

바꾼 코드로 실행 시 화면입니다. 

## 🔗 관련 이슈
현재 postman으로 백엔드 API들은 정상 작동되는게 확인이 되는데, 프론트엔드랑 연결해서 웹에서 실행해보면 오류가 발생합니다.
아무래도 만들어진 프론트엔드 코드들과 충돌이 있는 듯 합니다. 프론트엔드 코드를 수정하거나, 백엔드 코드들을 프론트엔드 코드에 맞게 다시 수정하는 작업이 필요할 것 같습니다.

## 💬 리뷰어에게
확인 부탁드립니다.