### PR TITLE
feat: swagger 출력 파일 생성 스크립트 추가

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "seed": "node seed.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "docs": "node ./swagger/export-swagger.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/swagger/export-swagger.js
+++ b/backend/swagger/export-swagger.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const fs = require('fs');
+const { swaggerSpec } = require('./swagger');
+
+const outputPath = path.join(__dirname, 'swagger-output.json'); // 절대경로 사용
+fs.writeFileSync(outputPath, JSON.stringify(swaggerSpec, null, 2));
+console.log('✅ swagger-output.json 파일이 생성되었습니다!');


### PR DESCRIPTION
## 📝 요구사항
- [x] 자동화 테스트를 위한 swagger 병합 파일 덤프

## ✨ 주요 변경사항
- 파일 덤프 코드 및 실행 명령어 작성

## 📸 스크린샷 (선택)
덤프 완료 로그
![image](https://github.com/user-attachments/assets/3b566925-ed8e-4a82-95f8-e96211d455aa)
덤프된 json 파일
![image](https://github.com/user-attachments/assets/051e3bca-5e41-4fbd-94bc-5297305c4b63)

## 🔗 관련 이슈
<!-- #이슈번호 -->

## 💬 리뷰어에게
현재 Swagger 설정이 swagger.js와 openapi.yaml로 분리되어 있어 병합된 JSON 스펙을 덤프하도록 작업한 내용입니다
수동으로 덤프 하는 방식이 나을 듯 하여 별도 파일로 구성하여 진행했습니다.

- 실행 방법 :터미널 'npm run docs'로 실행 -> swagger 폴더 내 swagger-output.json 파일