### PR TITLE
[feature/recordManagePre] 이전 DB로 그룹 기록 생성, 디스코드 메시지 보내기 완성 및 테스트 완료

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -29,3 +29,4 @@ node_modules/@prisma/client
 generated/
 generated/prisma/
 .prisma/
+*.http

--- a/backend/controllers/records-controller.js
+++ b/backend/controllers/records-controller.js
@@ -141,7 +141,7 @@ class RecordController {
         authorPassword,
       } = req.body;
 
-      console.log(req.body);
+      // console.log(req.body);
 
       // 전달받은 그룹의 아이디를 통해서 그룹을 검색한다. 그룹이 없다면, null을 리턴한다.
       const group = await prisma.group.findUnique({

--- a/backend/controllers/records-controller.js
+++ b/backend/controllers/records-controller.js
@@ -1,6 +1,9 @@
 const { PrismaClient } = require('@prisma/client');
-const { object, string, optional, enums, validate, StructError } = require('superstruct');
+const { object, string, optional, enums, validate, StructError, array, number, assert } = require('superstruct');
 const prisma = new PrismaClient();
+const { hashPassword, comparePassword } = require('../utils/password.js');
+const { ERROR_MSG, STATUS_CODE } = require('../utils/const');
+const handleError = require('../utils/error');
 
 class RecordController {
   /**
@@ -102,6 +105,118 @@ class RecordController {
       return res.status(200).json({ data, total });
     } catch (err) {
       next(err);
+    }
+  }
+
+  static async createGroupRecord(req, res, next) {
+    try {
+
+      try {
+        const reqGroupIdVerifyStruct = string();
+        const reqBodyVerifyStruct = object({
+          exerciseType: enums(['run', 'bike', 'swim']),
+          description: string(),
+          time: number(),
+          distance: number(),
+          photos: array(string()),
+          authorNickname: string(),
+          authorPassword: string(),
+        });
+
+        assert(req.params.groupId, reqGroupIdVerifyStruct);
+        assert(req.body, reqBodyVerifyStruct);
+      } catch (err) {
+        return next(err);
+      }
+
+      // 요청 데이터를 받아서 숫자로 변환한다.
+      const groupId = Number(req.params.groupId);
+      const {
+        exerciseType: sport,
+        description,
+        time: duration,
+        distance,
+        photos,
+        authorNickname,
+        authorPassword,
+      } = req.body;
+
+      console.log(req.body);
+
+      // 전달받은 그룹의 아이디를 통해서 그룹을 검색한다. 그룹이 없다면, null을 리턴한다.
+      const group = await prisma.group.findUnique({
+        where: { id: groupId }
+      });
+
+      if (!group) return handleError(res, null, ERROR_MSG.GROUP_NOT_FOUND, STATUS_CODE.BAD_REQUEST);
+
+      // 유저가 있는지 확인한다. 유저가 없으면, 생성해야 한다.
+      let user = await prisma.user.findUnique({
+        where: { nickname: authorNickname },
+      });
+
+      // 유저가 있는데 비번이 틀리면 에러가 발생한다.
+      if (user && await comparePassword(authorPassword, user.password) === false) {
+        return handleError(res, null, ERROR_MSG.PASSWORD_MISMATCH, STATUS_CODE.UNAUTHORIZED)
+      }
+
+      // 유저가 아예 없다면, 새로 생성한다.
+      if (!user) {
+        user = await prisma.user.create({
+          data: {
+            nickname: authorNickname,
+            password: await hashPassword(authorPassword)
+          }
+        });
+      }
+
+      // 운동 기록을 생성한다.
+      const recordObj = await prisma.exerciseRecord.create({
+        data: {
+          sport,
+          description,
+          duration,
+          distance,
+          userId: user.id,
+          groupId
+        }
+      });
+
+      for (const photo of photos) {
+        await prisma.photo.create({
+          data: {
+            url: photo,
+            photoTag: "EXERCISERECORD",
+            exerciseRecordId: recordObj.id
+          }
+        });
+      }
+
+      const groupWebHook = group.discordWebhookUrl;
+
+      const resFromDiscord = await fetch(groupWebHook, {
+        method: 'POST',
+        headers: {'content-Type': 'application/json'},
+        body: JSON.stringify({content: '운동기록이 생성되었습니다.'})
+      });
+
+      // console.log(resFromDiscord);
+
+      return res.status(STATUS_CODE.CREATED).json({
+        id: recordObj.id,
+        exerciseType: sport,
+        description,
+        time: duration,
+        distance,
+        photos,
+        author: {
+          id: user.id,
+          nickname: user.nickname
+        }
+      });
+
+    } catch (err) {
+      return handleError(res, err, ERROR_MSG.SERVER_ERROR, STATUS_CODE.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -41,6 +41,7 @@ router
   .route('/:groupId/participants')
   .post(groupDataValidation, GroupParticipantController.postGroupParticipant) // 그룹 참여 API
   .delete(groupDataValidation, GroupParticipantController.deleteGroupParticipant); // 그룹 참여 취소 API
+  const RecordController = require('../controllers/records-controller');
 
 /**
  * 그룹 생성 API
@@ -59,6 +60,10 @@ router.patch('/:groupId', GroupController.patchGroup);
  * DELETE /groups/:groupId
  */
 router.delete('/:groupId', GroupController.deleteGroup);
+
+// 그룹 기록 생성
+// POST /groups/:groupId/records
+router.post('/:groupId/records', RecordController.createGroupRecord);
 
 // 그룹 ID를 기준으로 하는 기록 관련 하위 라우터 연결
 router.use('/:groupId', recordRouter);

--- a/backend/routes/groups.js
+++ b/backend/routes/groups.js
@@ -41,7 +41,6 @@ router
   .route('/:groupId/participants')
   .post(groupDataValidation, GroupParticipantController.postGroupParticipant) // 그룹 참여 API
   .delete(groupDataValidation, GroupParticipantController.deleteGroupParticipant); // 그룹 참여 취소 API
-  const RecordController = require('../controllers/records-controller');
 
 /**
  * 그룹 생성 API
@@ -60,10 +59,6 @@ router.patch('/:groupId', GroupController.patchGroup);
  * DELETE /groups/:groupId
  */
 router.delete('/:groupId', GroupController.deleteGroup);
-
-// 그룹 기록 생성
-// POST /groups/:groupId/records
-router.post('/:groupId/records', RecordController.createGroupRecord);
 
 // 그룹 ID를 기준으로 하는 기록 관련 하위 라우터 연결
 router.use('/:groupId', recordRouter);

--- a/backend/routes/records.js
+++ b/backend/routes/records.js
@@ -22,4 +22,8 @@ router.get('/records/:recordId', RecordViewController.getRecordById);
  */
 router.get('/records', RecordsController.getGroupRecords);
 
+// 그룹 기록 생성
+// POST /groups/:groupId/records
+router.post('/records', RecordsController.createGroupRecord);
+
 module.exports = router;


### PR DESCRIPTION
## 📝 요구사항
**기록 등록**
- [x] 닉네임, 운동 종류(달리기, 자전거, 수영), 설명, 시간, 거리, 사진(여러장 가능), 비밀번호를 입력하여 운동 기록을 등록합니다.
- [x] 타이머를 통해 측정된 실제 운동한 만큼의 시간만 입력 가능합니다.
- [x] 닉네임, 비밀번호를 확인하여 그룹에 등록된 유저일 때만 기록 등록이 가능합니다.
- [x] 새로운 운동 기록이 등록 되었을 때 그룹에 등록된 디스코드 웹 서버로 알림을 전송합니다.

## ✨ 주요 변경사항
request.http를 추가했습니다.
const.js를 정리했습니다.
group.js에 해당 static 메서드를 등록했습니다.
강사님이 알려주신 DB 스키마가 아닌 기존 DB 스키마를 사용했습니다.

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fb7fd0e9-2afd-44ba-a144-c5ad59e221a2)
![image](https://github.com/user-attachments/assets/859661a4-5b18-4560-9d1a-587268a61cd8)

## 🔗 관련 이슈

## 💬 리뷰어에게
추가로 수정할 부분이나 개선 사항이 있으면 알려주세요